### PR TITLE
fix flaky test on test_dictionary.py::test_dictionary_looping

### DIFF
--- a/codespell_lib/tests/test_dictionary.py
+++ b/codespell_lib/tests/test_dictionary.py
@@ -195,9 +195,27 @@ allowed_dups = {
     ('dictionary_rare.txt', 'dictionary_usage.txt'),
 }
 
+# variable record how many loop executed in case multiple runs of the test, initialize the dictionary 
+duplicates_dict_num = 0
+
+
+@pytest.fixture(scope="function")
+def initialize_dictionary():
+    """ initialize the dictionary """
+    global duplicates_dict_num
+    duplicates_dict_num += 1
+    print(duplicates_dict_num)
+    if duplicates_dict_num == len(_fnames_in_aspell)+1:
+        global global_err_dicts
+        global_err_dicts = dict()
+        global global_pairs
+        global_pairs = set()
+        duplicates_dict_num = 1
+
 
 @fname_params
 @pytest.mark.dependency(name='dictionary loop')
+@pytest.mark.usefixtures("initialize_dictionary")
 def test_dictionary_looping(fname, in_aspell, in_dictionary):
     """Test that all dictionary entries are valid."""
     this_err_dict = dict()

--- a/codespell_lib/tests/test_dictionary.py
+++ b/codespell_lib/tests/test_dictionary.py
@@ -195,7 +195,7 @@ allowed_dups = {
     ('dictionary_rare.txt', 'dictionary_usage.txt'),
 }
 
-# variable record how many loop executed in case multiple runs of the test, initialize the dictionary 
+# variable record how many loop executed in case multiple runs of the test, initialize the dictionary
 duplicates_dict_num = 0
 
 
@@ -204,7 +204,6 @@ def initialize_dictionary():
     """ initialize the dictionary """
     global duplicates_dict_num
     duplicates_dict_num += 1
-    print(duplicates_dict_num)
     if duplicates_dict_num == len(_fnames_in_aspell)+1:
         global global_err_dicts
         global_err_dicts = dict()

--- a/codespell_lib/tests/test_dictionary.py
+++ b/codespell_lib/tests/test_dictionary.py
@@ -205,13 +205,12 @@ allowed_dups = {
 # variable record how many loop executed in case multiple runs of the test, initialize the dictionary
 duplicates_dict_num = 0
 
-
 @pytest.fixture(scope="function")
 def initialize_dictionary():
     """ initialize the dictionary """
     global duplicates_dict_num
     duplicates_dict_num += 1
-    if duplicates_dict_num == len(_fnames_in_aspell)+1:
+    if duplicates_dict_num >= len(_fnames_in_aspell)+1:
         global global_err_dicts
         global_err_dicts = dict()
         global global_pairs


### PR DESCRIPTION
This PR aims to fix the flaky test on **test_dictionary.py::test_dictionary_looping**  so the test could pass for multiple test runs 

#### The result

The test can pass when running only once, but fail when running the test suit multiple times. When asserting the key pair does not exist on the `global_err_dicts ` or `global_pairs`, the pair actually exist start on the second test run. 

#### Steps to reproduce the issue

1.  install pytest flaky finder with `pip install pytest-flakefinder`
2.  run pytest with flake-finder with command  `pytest -k test_dictionary.py --flake-finder`

#### Issue of the code

The reason is the code tried to assert the key pair or error read from the file doesn't exist. However, the `global_err_dicts ` and `global_pairs` only initialize once per pytest runs, so start from the second run of `test_dictionary_looping`, the assert will fail.

#### Proposed solution
Adding a variable to track how many txt files we had read. With a pytest fixture to initialize both global_err_dicts ` and `global_pairs` if the variable indicates it is a new test run. 

